### PR TITLE
add long press on press support for Bilresa

### DIFF
--- a/ikea-bilresa-e2489-matter-smart-button/ikea-bilresa-e2489-matter-smart-button.yaml
+++ b/ikea-bilresa-e2489-matter-smart-button/ikea-bilresa-e2489-matter-smart-button.yaml
@@ -1,12 +1,13 @@
 # ===================================================================
 # IKEA BILRESA E2489 Dual Button
-# Blueprint Template v1.0.3
+# Blueprint Template v1.1.0
 #
 # Internal Versioning:
-#   schema_version: 1.0.3
-#   last_updated: 2025-12-27
+#   schema_version: 1.1.0
+#   last_updated: 2026-02-27
 #
 # Changelog:
+#   v1.1.0: Added support for long press actions on press (long_press)
 #   v1.0.3: Added not_from/not_to filters to prevent re-triggering on HA/Matter restarts (https://community.home-assistant.io/t/ikea-bilresa-matter-button-blueprint-for-ikea-matter-over-thread-button-actions-scripts-and-entities/962344/12)
 #   v1.0.2: Initial release
 #
@@ -21,7 +22,7 @@ blueprint:
   author: censay
   description: >
     Full-featured automation for the IKEA BILRESA E2489 Matter dual-button
-    remote. Supports single press, double press, and long press (on release)
+    remote. Supports single press, double press, and long press (on press and on release)
     for both buttons. Uses event entities exposed by Home Assistant for
     Matter devices. Single-press actions are prioritized for reliability.
   domain: automation
@@ -75,6 +76,13 @@ blueprint:
       selector:
         action: {}
 
+    button1_long_press:
+      name: Button 1 – Long Press (on press)
+      description: Action for Button 1 long press start (long_press).
+      default: []
+      selector:
+        action: {}
+
     button1_long:
       name: Button 1 – Long Press (on release)
       description: Action for Button 1 long press completion (long_release).
@@ -96,6 +104,13 @@ blueprint:
     button2_double:
       name: Button 2 – Double Press
       description: Action for Button 2 double press (multi_press_2).
+      default: []
+      selector:
+        action: {}
+
+    button2_long_press:
+      name: Button 2 – Long Press (on press)
+      description: Action for Button 2 long press start (long_press).
       default: []
       selector:
         action: {}
@@ -154,6 +169,12 @@ action:
         sequence: !input button1_double
 
       - conditions:
+        - condition: template
+          value_template: >
+            {{ trigger_id == 'button1' and press_type == 'long_press' }}
+        sequence: !input button1_long_press
+
+      - conditions:
           - condition: template
             value_template: >
               {{ trigger_id == 'button1' and press_type == 'long_release' }}
@@ -174,6 +195,12 @@ action:
             value_template: >
               {{ trigger_id == 'button2' and press_type == 'multi_press_2' }}
         sequence: !input button2_double
+
+      - conditions:
+        - condition: template
+          value_template: >
+            {{ trigger_id == 'button2' and press_type == 'long_press' }}
+        sequence: !input button2_long_press
 
       - conditions:
           - condition: template


### PR DESCRIPTION
Heyhey,

first of all: thank you very much for providing these.

I wanted to reach to you on LinkedIn, but turns out I'd apparently need "Premium" for that, which I do not have. I did send you an invite however. So I decided to directly go with a PullRequest. I hope that's ok. If not: sorry :smile: .

This PR adds support for the on-press portion of the long-press for both buttons of the Ikea Bilresa dual button remote. I prefer to use that over release, because it gives me more instant feedback.

Since this should be backward compatible (as in: existing automations should continue to work just fine), but not forward compatible (automations created with this version will not work with older ones) I decided to increase minor version.

And while I'm at it: I noticed the repository does not provide a License. That is not optimal for everybody involved, and I highly recommend adding one. In case you don't know which, I'd recommend the [MIT License](https://en.wikipedia.org/wiki/MIT_License) which is basically "everybody can do whatever they want with it, but you cannot be sued for anything that goes wrong because of your stuff".

Cheers,
Juri